### PR TITLE
Fix nil parameters handling

### DIFF
--- a/lib/coreos_ami.rb
+++ b/lib/coreos_ami.rb
@@ -31,16 +31,21 @@ class CoreOS
 
   ## return hash of all AMIs for release version
   def amis(opt = {})
-    args = DEFAULTS.merge(opt)
+    args = parse opt
     path = [ base_url, args[:release].to_s, 'coreos_production_ami_all.json' ].join('/')
     JSON.parse(get(path))
   end
 
   ## return AMI name as string
   def ami(opt = {})
-    args = DEFAULTS.merge(opt)
+    args = parse opt
     path = [ base_url, args[:release].to_s, "coreos_production_ami_#{args[:virtualization]}_#{args[:region]}.txt" ].join('/')
     get(path)
   end
 
+  private
+
+  def parse(opt)
+    DEFAULTS.merge(opt) { |_, from_default, from_opt| from_opt || from_default }
+  end
 end


### PR DESCRIPTION
Previous nil would override default values

```
[1] pry(main)> require 'coreos_ami' # previous version
=> true
[2] pry(main)> CoreOS.channel('stable').ami region: 'us-east-1', release: '835.13.0'
=> "ami-7f3a0b15"
[3] pry(main)> CoreOS.channel('stable').ami region: 'us-east-1', release: nil #nil generates error
=> "<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>"
[4] pry(main)> load 'lib/coreos_ami.rb' # loading this patch
lib/coreos_ami.rb:6: warning: already initialized constant CoreOS::DEFAULTS
/Users/jonas/.gem/ruby/2.3.0/gems/coreos_ami-0.0.3/lib/coreos_ami.rb:6: warning: previous definition of DEFAULTS was here
=> true
[5] pry(main)> CoreOS.channel('stable').ami region: 'us-east-1', release: nil
=> "ami-2c393546"
[6] pry(main)>
```
